### PR TITLE
Working Professionals cohort: expressions of interest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,11 @@ Next.js 16 app (App Router) with Tailwind CSS v4. Deployed on Vercel.
 **API routes** submit to Airtable:
 - `POST /api/qr-signup` - Email capture (writes to Email List table)
 - `POST /api/apply` - Summer intensive application with resume upload
+- `POST /api/working-professionals-eoi` - Working Professionals expression-of-interest (name, email, LinkedIn/portfolio). Writes to the "Working Professionals EOI" table (`tblvuakrOt7JSZPdT`) in the "Summer Intensives" base (`appVfG77MoQbG3bgi`). Surfaced on `/summer-intensive`.
 
 **Environment variables** (set in Vercel): `AIRTABLE_PAT`, `AIRTABLE_BASE_ID`, `AIRTABLE_TABLE_ID`, `AIRTABLE_RESUME_FIELD_ID`
+
+**Local secrets / testing:** The Airtable PAT for local dev lives at `~/.claude/taisi-secrets.env` (machine-level, never committed). Copy `AIRTABLE_PAT` from there into a gitignored `.env.local` at the repo root before running `npm run dev` against Airtable. The PAT also has Airtable metadata (schema) read/write, so you can list bases/tables via `https://api.airtable.com/v0/meta/bases`.
 
 **Layout:** `layout.tsx` renders shared `Nav` component and footer. Nav is a client component with mobile hamburger menu.
 

--- a/src/app/api/working-professionals-eoi/route.ts
+++ b/src/app/api/working-professionals-eoi/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PAT = process.env.AIRTABLE_PAT!;
+// Summer Intensives base -> "Working Professionals EOI" table
+const BASE_ID = "appVfG77MoQbG3bgi";
+const TABLE_ID = "tblvuakrOt7JSZPdT";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, email, link, availability } = await req.json();
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    }
+
+    const fields: Record<string, string | string[]> = {
+      Email: email,
+    };
+    if (typeof name === "string" && name.trim()) fields["Name"] = name.trim();
+    if (typeof link === "string" && link.trim()) {
+      fields["LinkedIn or Portfolio"] = link.trim();
+    }
+    if (Array.isArray(availability)) {
+      const days = availability.filter(
+        (d): d is string => typeof d === "string" && d.trim() !== ""
+      );
+      if (days.length > 0) fields["Availability"] = days;
+    }
+
+    const res = await fetch(
+      `https://api.airtable.com/v0/${BASE_ID}/${TABLE_ID}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${PAT}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ records: [{ fields }] }),
+      }
+    );
+
+    if (!res.ok) {
+      const error = await res.text();
+      console.error("Airtable EOI error:", error);
+      return NextResponse.json(
+        { error: "Failed to submit your interest" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    console.error("EOI submit error:", e);
+    return NextResponse.json(
+      { error: "Failed to submit your interest" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -156,6 +156,15 @@ function HomeInner() {
               We are a sister organization to AI safety groups at MIT, Harvard, and Cambridge.
             </p>
           </div>
+
+          <div className="intro-rise mt-8 sm:mt-10" style={{ animationDelay: "3800ms" }}>
+            <a
+              href="/summer-intensive"
+              className="primary-cta px-7 py-3.5 text-[15px] sm:text-[16px]"
+            >
+              Express interest in our August cohort
+            </a>
+          </div>
         </div>
 
         <div
@@ -295,7 +304,7 @@ function HomeInner() {
             <a href="/fellowships" className="text-accent hover:underline">Fellowship</a> applications reopen late summer.
           </p>
           <p>
-            <a href="/summer-intensive" className="text-accent hover:underline">Intensive</a> applications are closed.
+            <a href="/summer-intensive" className="text-accent hover:underline">Intensive</a> expressions of interest are open for our working professionals cohort this August.
           </p>
         </div>
       </section>

--- a/src/app/summer-intensive/page.tsx
+++ b/src/app/summer-intensive/page.tsx
@@ -1,3 +1,5 @@
+import WorkingProfessionalsForm from "@/components/WorkingProfessionalsForm";
+
 export default function SummerIntensive() {
   return (
     <main>
@@ -8,7 +10,8 @@ export default function SummerIntensive() {
 
         <div className="text-[17px] sm:text-[19px] leading-[1.7] text-text mb-8 space-y-4">
           <p className="font-semibold">
-            Applications for the Summer 2026 intensive are now closed.
+            Expressions of interest are open for our{" "}
+            <span className="text-accent">working professionals cohort this August</span>.
           </p>
 
           <hr className="border-t border-gray-200 !my-8" />
@@ -19,11 +22,11 @@ export default function SummerIntensive() {
           <ul className="space-y-2 pl-0 list-none">
             <li className="flex gap-2.5">
               <span className="text-accent font-bold shrink-0">&#8594;</span>
-              <span>One day/week (Sat or Sun), <strong>compatible with internships or other summer commitments</strong></span>
+              <span>One day/week (Sat or Sun), <strong>built to fit around a full-time job</strong></span>
             </li>
             <li className="flex gap-2.5">
               <span className="text-accent font-bold shrink-0">&#8594;</span>
-              <span>Hosted at Trajectory Labs, an off-campus AI safety lab near King Station</span>
+              <span>Held in person at Trajectory Labs, an off-campus AI safety lab in downtown Toronto near King Station</span>
             </li>
             <li className="flex gap-2.5">
               <span className="text-accent font-bold shrink-0">&#8594;</span>
@@ -39,8 +42,18 @@ export default function SummerIntensive() {
             </li>
           </ul>
           <p>
-            Cohorts monthly May&ndash;August. No prior ML or AI safety experience required.
+            The working professionals cohort runs in person in Toronto this August. No prior ML or AI safety experience required.
           </p>
+        </div>
+
+        <hr className="border-t border-gray-200 !my-8 max-w-[560px] mx-0" />
+
+        <div>
+          <h2 className="section-header mb-4">Express your interest</h2>
+          <p className="text-[16px] sm:text-[17px] leading-[1.7] text-text-secondary mb-6 max-w-[560px]">
+            Share your details and we&rsquo;ll follow up with dates and next steps. This is not an application, just a way to let us know you&rsquo;re interested.
+          </p>
+          <WorkingProfessionalsForm />
         </div>
       </section>
     </main>

--- a/src/components/WorkingProfessionalsForm.tsx
+++ b/src/components/WorkingProfessionalsForm.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { FormField, SuccessPanel } from "@/components/FormControls";
+
+const NOT_AVAILABLE = "Not available this August";
+const DAY_OPTIONS = ["Saturdays", "Sundays", NOT_AVAILABLE];
+
+export default function WorkingProfessionalsForm() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [link, setLink] = useState("");
+  const [days, setDays] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [joinedMailingList, setJoinedMailingList] = useState(false);
+  const [error, setError] = useState("");
+
+  const notAvailable = days.includes(NOT_AVAILABLE);
+
+  function toggleDay(day: string) {
+    setDays((prev) => {
+      // "Not available" is mutually exclusive with the day options.
+      if (day === NOT_AVAILABLE) {
+        return prev.includes(NOT_AVAILABLE) ? [] : [NOT_AVAILABLE];
+      }
+      const withoutNA = prev.filter((d) => d !== NOT_AVAILABLE);
+      return withoutNA.includes(day)
+        ? withoutNA.filter((d) => d !== day)
+        : [...withoutNA, day];
+    });
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError("");
+
+    if (days.length === 0) {
+      setError("Please indicate your availability.");
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      if (notAvailable) {
+        // Not available for this cohort: just add them to the mailing list.
+        const res = await fetch("/api/subscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, source: "working-professionals-eoi" }),
+        });
+        if (!res.ok) throw new Error("Failed");
+        setJoinedMailingList(true);
+      } else {
+        const res = await fetch("/api/working-professionals-eoi", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, email, link, availability: days }),
+        });
+        if (!res.ok) throw new Error("Failed");
+      }
+      setDone(true);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (done) {
+    return joinedMailingList ? (
+      <SuccessPanel title="You&rsquo;re on the list" className="!mx-0 !mt-0">
+        <p>
+          Thanks. We&rsquo;ve added you to our mailing list and will keep you posted on future events and cohorts.
+        </p>
+      </SuccessPanel>
+    ) : (
+      <SuccessPanel title="Thanks for your interest" className="!mx-0 !mt-0">
+        <p>
+          We&rsquo;ve recorded your interest in the working professionals cohort and will be in touch with dates and next steps.
+        </p>
+      </SuccessPanel>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-[560px] space-y-6">
+      {error && (
+        <p className="text-accent text-[15px] font-medium">{error}</p>
+      )}
+
+      <FormField label="Name" required>
+        <input
+          type="text"
+          name="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="form-input"
+        />
+      </FormField>
+
+      <FormField label="Email" required>
+        <input
+          type="email"
+          name="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="form-input"
+        />
+      </FormField>
+
+      <FormField
+        label="LinkedIn or portfolio"
+        required={!notAvailable}
+        hint={notAvailable ? "Optional" : undefined}
+      >
+        <input
+          type="url"
+          name="link"
+          value={link}
+          onChange={(e) => setLink(e.target.value)}
+          required={!notAvailable}
+          className="form-input"
+          placeholder="https://..."
+        />
+      </FormField>
+
+      <FormField
+        label="Which days can you attend?"
+        required
+        hint="One cohort meets every Saturday and the other meets every Sunday. Indicate your availability."
+      >
+        <div className="space-y-2">
+          {DAY_OPTIONS.map((day) => (
+            <label
+              key={day}
+              className="flex items-center gap-3 border border-black/20 px-4 py-3 text-[15px] text-text cursor-pointer hover:border-black/40 transition-colors"
+            >
+              <input
+                type="checkbox"
+                checked={days.includes(day)}
+                onChange={() => toggleDay(day)}
+                className="h-4 w-4 shrink-0 accent-accent"
+              />
+              <span>{day}</span>
+            </label>
+          ))}
+        </div>
+      </FormField>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="primary-cta px-8 py-3 text-[15px] disabled:cursor-not-allowed"
+      >
+        {submitting
+          ? "Submitting..."
+          : notAvailable
+            ? "Join mailing list"
+            : "Express interest"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
Reopens `/summer-intensive` around the **working professionals August cohort** (in person in Toronto) with an expression-of-interest form.

## Changes
- **Summer Intensive page** reframed: EOI open for the working professionals cohort this August, with the in-person Toronto location made explicit.
- **EOI form** (`WorkingProfessionalsForm`): name, email, required LinkedIn/portfolio, and Saturday/Sunday availability. Posts to the new `POST /api/working-professionals-eoi` route, which writes to the **"Working Professionals EOI"** table in the Summer Intensives Airtable base.
- **"Not available this August"** option: routes the person to the mailing list (`/api/subscribe`) instead of the EOI table, and confirms they'll be kept posted on future events.
- **Homepage**: added a hero CTA ("Express interest in our August cohort") linking to the page, and updated the "What do we run?" line.
- **CLAUDE.md**: documented the new route/table and the local Airtable PAT location.

## Notes
- Two `Email` and `LinkedIn or Portfolio` fields plus an `Availability` multi-select were added to the EOI table via the Airtable schema API. No new env vars are required (reuses `AIRTABLE_PAT`).
- "Not available" submissions are added to the mailing list only, not the EOI table (keeps the EOI table to actual August candidates). Easy to change if you'd prefer recording both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)