### PR TITLE
Improve active navigation styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,18 +15,36 @@
 }
 
 @keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
 }
 
 @keyframes intro-rise {
-  from { opacity: 0; transform: translateY(12px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes intro-fade {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .intro-rise {
@@ -51,14 +69,17 @@
   border-radius: 0 !important;
   transition: border-color 0.15s ease;
 }
+
 .form-input:focus {
   outline: none;
   border-color: var(--color-accent);
   box-shadow: 0 0 0 1px var(--color-accent);
 }
+
 .form-input::placeholder {
   color: #9ca3af;
 }
+
 .form-select {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -76,12 +97,15 @@
   box-shadow: 0 0 0 rgba(22, 107, 159, 0);
   transition: box-shadow 0.2s ease-out;
 }
+
 .primary-cta:hover {
   box-shadow: 7px 7px 0 rgba(22, 107, 159, 0.48);
 }
+
 .primary-cta:active {
   box-shadow: 3px 3px 0 rgba(22, 107, 159, 0.42);
 }
+
 .primary-cta:disabled {
   opacity: 0.5;
   box-shadow: none;
@@ -98,12 +122,15 @@
   box-shadow: 0 0 0 rgba(22, 107, 159, 0);
   transition: box-shadow 0.2s ease-out;
 }
+
 .secondary-cta:hover {
   box-shadow: 7px 7px 0 rgba(22, 107, 159, 0.48);
 }
+
 .secondary-cta:active {
   box-shadow: 3px 3px 0 rgba(22, 107, 159, 0.42);
 }
+
 .secondary-cta:disabled {
   opacity: 0.5;
   box-shadow: none;
@@ -117,6 +144,78 @@
   text-decoration-line: underline;
   text-decoration-thickness: 2px;
   text-underline-offset: 4px;
+}
+
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  padding: 0.35rem 0;
+  transition: color 160ms ease;
+}
+
+.nav-link::after {
+  position: absolute;
+  bottom: -0.25rem;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  content: "";
+  background-color: var(--color-accent);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 180ms ease;
+}
+
+.nav-link:hover {
+  color: var(--color-accent);
+}
+
+.nav-link:hover::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.nav-link-active {
+  color: var(--color-text);
+}
+
+.nav-link-active::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.nav-link:focus-visible {
+  color: var(--color-accent);
+  outline: 2px solid var(--color-accent);
+  outline-offset: 5px;
+}
+
+.mobile-nav-link {
+  display: flex;
+  align-items: center;
+  min-height: 3.25rem;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid transparent;
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease;
+}
+
+.mobile-nav-link:hover {
+  color: var(--color-accent);
+  background-color: rgb(217 79 48 / 6%);
+}
+
+.mobile-nav-link-active {
+  color: var(--color-text);
+  background-color: rgb(217 79 48 / 8%);
+  border-left-color: var(--color-accent);
+}
+
+.mobile-nav-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 @media (min-width: 640px) {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 const links = [
@@ -17,23 +17,26 @@ export default function Nav() {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
 
-  useEffect(() => { setMounted(true); }, []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-  // Close mobile menu on route change
   useEffect(() => {
     setOpen(false);
   }, [pathname]);
 
-  // Prevent scroll when menu is open
   useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
-    return () => { document.body.style.overflow = ""; };
+
+    return () => {
+      document.body.style.overflow = "";
+    };
   }, [open]);
 
   return (
     <>
-      <nav className="sticky top-0 z-[100] bg-white/60 backdrop-blur-md border-b border-black/10">
-        <div className="flex items-center justify-between px-5 sm:px-8 md:px-16 lg:px-24 py-4">
+      <nav className="sticky top-0 z-[100] border-b border-black/10 bg-white/60 backdrop-blur-md">
+        <div className="flex items-center justify-between px-5 py-4 sm:px-8 md:px-16 lg:px-24">
           <Link href="/" className="flex items-center gap-2.5">
             <Image
               src="/icon.png"
@@ -41,35 +44,51 @@ export default function Nav() {
               width={155}
               height={193}
               priority
-              className="h-[28px] sm:h-[32px] w-auto translate-y-[2px]"
+              className="h-[28px] w-auto translate-y-[2px] sm:h-[32px]"
             />
-            <span className="text-[15px] sm:text-[17px] font-normal tracking-tight text-text">
+
+            <span className="text-[15px] font-normal tracking-tight text-text sm:text-[17px]">
               Toronto AI Safety Initiative
             </span>
           </Link>
 
-          {/* Desktop links */}
-          <div className="hidden md:flex items-center gap-8 text-[15px] font-medium text-text-secondary">
-            {links.map(({ href, label }) => (
-              <Link
-                key={href}
-                href={href}
-                className={`hover:text-accent transition-colors ${
-                  pathname === href ? "text-text" : ""
-                }`}
-              >
-                {label}
-              </Link>
-            ))}
+          <div className="hidden items-center gap-8 text-[15px] font-medium md:flex">
+            {links.map(({ href, label }) => {
+              const isActive = pathname === href;
+
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  aria-current={isActive ? "page" : undefined}
+                  className={`nav-link ${
+                    isActive
+                      ? "nav-link-active"
+                      : "text-text-secondary"
+                  }`}
+                >
+                  {label}
+                </Link>
+              );
+            })}
           </div>
 
-          {/* Mobile hamburger */}
           <button
-            className="md:hidden relative z-[100] p-2 -mr-2"
-            onClick={() => setOpen(!open)}
+            type="button"
+            className="relative z-[100] -mr-2 p-2 md:hidden"
+            onClick={() => setOpen((current) => !current)}
             aria-label={open ? "Close menu" : "Open menu"}
+            aria-expanded={open}
           >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
               {open ? (
                 <>
                   <line x1="6" y1="6" x2="18" y2="18" />
@@ -87,25 +106,33 @@ export default function Nav() {
         </div>
       </nav>
 
-      {/* Mobile menu - portaled to body so it escapes nav stacking context */}
-      {open && mounted && createPortal(
-        <div className="md:hidden fixed inset-0 bg-white z-[90] pt-[76px]">
-          <div className="flex flex-col px-5 pt-6 gap-6 text-[17px] font-medium">
-            {links.map(({ href, label }) => (
-              <Link
-                key={href}
-                href={href}
-                className={`hover:text-accent transition-colors ${
-                  pathname === href ? "text-text" : "text-text-secondary"
-                }`}
-              >
-                {label}
-              </Link>
-            ))}
-          </div>
-        </div>,
-        document.body
-      )}
+      {open &&
+        mounted &&
+        createPortal(
+          <div className="fixed inset-0 z-[90] bg-white pt-[76px] md:hidden">
+            <div className="flex flex-col gap-3 px-5 pt-6 text-[17px] font-medium">
+              {links.map(({ href, label }) => {
+                const isActive = pathname === href;
+
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    aria-current={isActive ? "page" : undefined}
+                    className={`mobile-nav-link ${
+                      isActive
+                        ? "mobile-nav-link-active"
+                        : "text-text-secondary"
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>,
+          document.body,
+        )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

This PR improves the visibility and consistency of the active navigation state across desktop and mobile layouts without changing the site’s routing or page structure.

## Changes

- adds a persistent accent underline to the active desktop navigation link
- adds an animated underline and accent colour on hover
- gives the active mobile navigation link a highlighted background and left border
- adds visible keyboard focus styles
- adds `aria-current="page"` to the active navigation link
- adds `aria-expanded` to the mobile menu button

## Desktop demo

The recording below shows the active-link and hover behaviour. The cursor is not visible, but the underline animation indicates which navigation item is being hovered.

[navigation-active-state-demo.webm](https://github.com/user-attachments/assets/fe66d81f-3d71-4ca5-83fe-08dea4cfbad6)

## Mobile demo

The recording below shows the mobile menu, active-page styling, and route changes on a narrow viewport.

[mobile-demo.webm](https://github.com/user-attachments/assets/6e317979-6322-40e0-aa67-b6243b461cd7)

## Verification

- confirmed the correct active state on all navigation routes
- tested desktop active, hover, and keyboard focus states
- tested the mobile menu and route changes
- tested responsive behaviour around the 768px breakpoint
- verified that page scrolling is restored after closing the mobile menu
- ran a successful production build with `npm run build`
- confirmed that the project compiles successfully and passes TypeScript checks

The production build completed successfully with no errors. The only build warnings concern the existing `metadataBase` configuration and are unrelated to this PR.
